### PR TITLE
Issue 8: Database Schema and Seed Data

### DIFF
--- a/server/prisma/migrations/20260901000000_lab2_models/migration.sql
+++ b/server/prisma/migrations/20260901000000_lab2_models/migration.sql
@@ -1,0 +1,107 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+-- CreateTable
+CREATE TABLE "requester_users" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "department" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "requester_users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "related_systems" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "related_systems_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tickets" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL DEFAULT 'MEDIUM',
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "attachments" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "filename" TEXT NOT NULL,
+    "storedPath" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "isRemoved" BOOLEAN NOT NULL DEFAULT false,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" TEXT,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "categories" ADD COLUMN     "description" TEXT,
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "requester_users_email_key" ON "requester_users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "related_systems_name_key" ON "related_systems"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tickets_ticketNumber_key" ON "tickets"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "tickets_requesterId_idx" ON "tickets"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "tickets_requesterId_createdAt_idx" ON "tickets"("requesterId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "tickets_categoryId_idx" ON "tickets"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "tickets_relatedSystemId_idx" ON "tickets"("relatedSystemId");
+
+-- CreateIndex
+CREATE INDEX "attachments_ticketId_idx" ON "attachments"("ticketId");
+
+-- CreateIndex
+CREATE INDEX "attachments_ticketId_isRemoved_idx" ON "attachments"("ticketId", "isRemoved");
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "requester_users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "related_systems"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "attachments" ADD CONSTRAINT "attachments_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,4 +1,5 @@
-// Prisma schema — datasource and generator are pre-wired.
+// Prisma schema — Lab 2 TokTickIT Requester Ticketing MVP
+// Datasource and generator are pre-wired.
 // Your DATABASE_URL lives in server/.env (copy it from .env.example).
 
 generator client {
@@ -10,8 +11,100 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum TicketStatus {
+  NEW
+  IN_PROGRESS
+  RESOLVED
+  CLOSED
+}
+
+model RequesterUser {
+  id         Int      @id @default(autoincrement())
+  name       String
+  email      String   @unique
+  department String
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  tickets Ticket[]
+
+  @@map("requester_users")
+}
+
 model Category {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  description String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  tickets Ticket[]
+
+  @@map("categories")
+}
+
+model RelatedSystem {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  category  String?
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets Ticket[]
+
+  @@map("related_systems")
+}
+
+model Ticket {
+  id                Int          @id @default(autoincrement())
+  ticketNumber      String       @unique
+  summary           String
+  description       String
+  requestedPriority Priority     @default(MEDIUM)
+  currentStatus     TicketStatus @default(NEW)
+
+  requesterId     Int
+  requester       RequesterUser @relation(fields: [requesterId], references: [id])
+  categoryId      Int
+  category        Category      @relation(fields: [categoryId], references: [id])
+  relatedSystemId Int
+  relatedSystem   RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  attachments Attachment[]
+
+  @@index([requesterId])
+  @@index([requesterId, createdAt])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+  @@map("tickets")
+}
+
+model Attachment {
+  id            Int       @id @default(autoincrement())
+  ticketId      Int
+  ticket        Ticket    @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  filename      String
+  storedPath    String
+  fileSize      Int
+  mimeType      String
+  isRemoved     Boolean   @default(false)
+  removedAt     DateTime?
+  removalReason String?
+  uploadedAt    DateTime  @default(now())
+
+  @@index([ticketId])
+  @@index([ticketId, isRemoved])
+  @@map("attachments")
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -2,23 +2,88 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-const categories = [
-  "Account and Access",
-  "Hardware",
-  "Software",
-  "Network",
+const categoriesData = [
+  { name: "Account and Access", description: "Login, passwords, permission requests" },
+  { name: "Hardware", description: "Laptops, monitors, printers, peripherals" },
+  { name: "Software", description: "OS, office apps, specialized tools" },
+  { name: "Network", description: "Wi-Fi, VPN, campus network connectivity" },
+];
+
+const relatedSystemsData = [
+  { name: "Email", category: "Account and Access" },
+  { name: "Campus Wi-Fi", category: "Network" },
+  { name: "VPN", category: "Network" },
+  { name: "LEB2 App", category: "Software" },
+  { name: "Grade Submission App", category: "Software" },
+  { name: "Printer", category: "Hardware" },
+  { name: "Corporate Laptop", category: "Hardware" },
+];
+
+const requestersData = [
+  {
+    name: "Jennifer Anderson",
+    email: "jennifer.a@kmutt.ac.th",
+    department: "Faculty of Engineering",
+    isActive: true,
+  },
+  {
+    name: "Michael Brown",
+    email: "michael.b@kmutt.ac.th",
+    department: "School of Information Technology",
+    isActive: true,
+  },
+  {
+    name: "Sarah Johnson",
+    email: "sarah.j@kmutt.ac.th",
+    department: "Faculty of Science",
+    isActive: true,
+  },
+  {
+    name: "David Lee",
+    email: "david.l@kmutt.ac.th",
+    department: "School of Architecture",
+    isActive: true,
+  },
+  {
+    name: "John Doe",
+    email: "john.d@kmutt.ac.th",
+    department: "Discontinued Staff",
+    isActive: false,
+  },
 ];
 
 async function main() {
-  console.log("Seeding IT request categories...");
-  for (const name of categories) {
+  console.log("Seeding Lab 2 Reference Data & Development Requesters...");
+
+  // 1. Seed Categories
+  for (const cat of categoriesData) {
     await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
+      where: { name: cat.name },
+      update: { description: cat.description },
+      create: { name: cat.name, description: cat.description },
     });
   }
-  console.log("Successfully seeded IT request categories.");
+  console.log("Successfully seeded 4 IT Categories.");
+
+  // 2. Seed Related Systems
+  for (const sys of relatedSystemsData) {
+    await prisma.relatedSystem.upsert({
+      where: { name: sys.name },
+      update: { category: sys.category },
+      create: { name: sys.name, category: sys.category },
+    });
+  }
+  console.log("Successfully seeded 7 Related Systems.");
+
+  // 3. Seed Development Requesters
+  for (const req of requestersData) {
+    await prisma.requesterUser.upsert({
+      where: { email: req.email },
+      update: { name: req.name, department: req.department, isActive: req.isActive },
+      create: req,
+    });
+  }
+  console.log("Successfully seeded 4 Active Requesters and 1 Inactive Requester.");
 }
 
 main()


### PR DESCRIPTION
Closes #14

### Summary
อัปเดต Prisma Schema และ Idempotent Seed Data สำหรับ Lab 2 ใน server/prisma/ ดังนี้:

- server/prisma/schema.prisma:
  - เพิ่ม Enums: Priority (LOW, MEDIUM, HIGH) และ TicketStatus (NEW, IN_PROGRESS, RESOLVED, CLOSED)
  - เพิ่ม Models: RequesterUser, Category, RelatedSystem, Ticket, Attachment
  - กำหนด Primary Keys, Foreign Keys, Soft Removal fields (isRemoved, removedAt, removalReason)
  - เพิ่ม Prisma Indexes: @@index([requesterId]), @@index([requesterId, createdAt]), @@index([categoryId]), @@index([relatedSystemId]), @@index([ticketId]), @@index([ticketId, isRemoved])
- server/prisma/seed.ts:
  - เพิ่ม Idempotent Upsert Seeding สำหรับ Categories (4 หมวดหมู่), Related Systems (7 ระบบ), Active Development Requesters (4 คน) และ Inactive Development Requester (1 คน)
  - รองรับการรันสคริปต์ซ้ำโดยไม่สร้างข้อมูลซ้ำซ้อน

รบกวน Reviewer ช่วยตรวจสอบและกด Merge เข้า lab2-staging ให้ด้วยค่ะ